### PR TITLE
Use file pointer instead of file, maybe fix crash

### DIFF
--- a/discussion_generator.py
+++ b/discussion_generator.py
@@ -11,7 +11,14 @@ print("press 'p' to stop")
 
 mixer.init()
 
+mp3_fp = BytesIO()
+
 def article():
+    global mp3_fp
+
+    mixer.music.unload()
+    mp3_fp.close()
+
     url = 'https://en.wikipedia.org/api/rest_v1/page/random/summary'
     headers = {'user-agent': 'random-discussions/0.0.1'}
     response = requests.get(url, headers=headers)
@@ -23,8 +30,9 @@ def article():
     print("\n")
     language = 'en'
 
-    mp3_fp = BytesIO()
     tts_result = gTTS(text=mytext, lang=language, slow=False)
+
+    mp3_fp = BytesIO()
 
     tts_result.write_to_fp(mp3_fp)
 

--- a/discussion_generator.py
+++ b/discussion_generator.py
@@ -1,6 +1,7 @@
 import requests
 import json 
 from gtts import gTTS
+from io import BytesIO
 from pygame import mixer
 import time
 from pynput.keyboard import Key, Listener
@@ -8,9 +9,11 @@ from pynput.keyboard import Key, Listener
 print("press 'o' key to generate a new discussion")
 print("press 'p' to stop")
 
+mixer.init()
+
 def article():
     url = 'https://en.wikipedia.org/api/rest_v1/page/random/summary'
-    headers = {'user-agent': 'my-app/0.0.1'}
+    headers = {'user-agent': 'random-discussions/0.0.1'}
     response = requests.get(url, headers=headers)
     json_response = json.loads(response.text)
 
@@ -20,12 +23,12 @@ def article():
     print("\n")
     language = 'en'
 
-    myobj = gTTS(text=mytext, lang=language, slow=False)
+    mp3_fp = BytesIO()
+    tts_result = gTTS(text=mytext, lang=language, slow=False)
 
-    myobj.save("discussion.mp3")
+    tts_result.write_to_fp(mp3_fp)
 
-    mixer.init()
-    mixer.music.load('discussion.mp3')
+    mixer.music.load(mp3_fp, "discussion.mp3")
     mixer.music.play()
 def on_press(key):
     if hasattr(key, 'char'):


### PR DESCRIPTION
This removes multiple calls to `mixer.init()`, which possibly caused Doug's crash, uses a file pointer instead of writing to a file to avoid useless disk i/o, and sets the user-agent of the API request.